### PR TITLE
fix: Fix pub initialize

### DIFF
--- a/roles/dart/tasks/main.yaml
+++ b/roles/dart/tasks/main.yaml
@@ -89,18 +89,15 @@
       vars:
         activated_list: >-
           {%- for file in activates.files -%}
-            file.path
+            {{ file.path }}
+            {%- if not loop.last -%}
+              ,
+            {%- endif -%}
           {%- endfor -%}
       when: item not in activated_list
     - name: Export PATH of pub if need
       lineinfile:
-        path: >-
-          {%- if ansible_user_id == 'root' -%}
-            /etc/profile.d/dart.sh
-          {%- else -%}
-            ansible_env.HOME + '/.bash_profile'
-          {%- endif -%}
+        path: "{{ ansible_env.HOME }}/.bash_profile"
         state: present
         create: yes
         line: "export PATH=$PATH:$HOME/.pub-cache/bin"
-  when: ansible_user_id != 'root'


### PR DESCRIPTION
`pub` の初期化時の動作を修正

- fix: `root` でも初期化を実行するように変更
- fix: アクティベート済みパッケージのチェックができていなかったのを修正

fix #7 #8